### PR TITLE
Improvements for HTML5/XHTML specifications.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8">
+  <meta charset="utf-8"/>
   <title>Portfolio Walker</title>
-  <link rel="stylesheet" href="css/normalize.css">
-  <link rel="stylesheet" href="css/style.css">
-  <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.no-icons.min.css" rel="stylesheet">
-  <link href="https://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css" rel="stylesheet">
-  <link rel="shortcut icon" href="css/favicon.ico" type="image/x-icon"/ >
+  <link rel="stylesheet" href="css/normalize.css"/>
+  <link rel="stylesheet" href="css/style.css"/>
+  <link href="https://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.no-icons.min.css" rel="stylesheet"/>
+  <link href="https://netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css" rel="stylesheet"/>
+  <link rel="shortcut icon" href="css/favicon.ico" type="image/x-icon"/ />
 </head>
 <body>
    <script type="text/javascript" src="js/libs/tabletop.js"></script>  
@@ -39,7 +39,7 @@
     
      <section id="top"></section>        
      <a class="nav" href="http://finviz.com/screener.ashx?v=340&s=ta_topgainers&o=-change" target="_blank"/>FinViz Top Stocks Today </a>
-     <br>
+     <br/>
     {{#each item in model}}
       <a class="link-to" href="#{{item}}"><span class="label label-warning">{{item}}</span></a>
     {{/each}}
@@ -65,7 +65,7 @@
           </td><td>
               <img src="http://stockcharts.com/c-sc/sc?s={{item}}&p=W&b=5&g=0&i=t99261714081&r=1408323404116"/>
           </td></tr></table>
-        <br>
+        <br/>
       </li>
 
     {{/each}}
@@ -117,7 +117,7 @@
       
       <section id="top"></section>        
       <a class="nav" href="http://finviz.com/screener.ashx?v=340&s=ta_topgainers&o=-change" target="_blank"/>FinViz Top Stocks Today </a>
-      <br>
+      <br/>
       {{#each item in model}}
           <a class="link-to" href="#{{item}}"><span class="label label-warning">{{item}}</span></a>
       {{/each}}
@@ -143,7 +143,7 @@
           </td><td>
               <img src="http://stockcharts.com/c-sc/sc?s={{item}}&p=W&b=5&g=0&i=t99261714081&r=1408323404116"/>
           </td></tr></table>
-        <br>
+        <br/>
       </li>
     {{/each}}
     </ul>
@@ -194,7 +194,7 @@
     
       <section id="top"></section>        
       <a class="nav" href="http://finviz.com/screener.ashx?v=340&s=ta_topgainers&o=-change" target="_blank"/>FinViz Top Stocks Today </a>
-      <br>
+      <br/>
     {{#each item in model}}
        <a class="link-to" href="#{{item}}"><span class="label label-warning">{{item}}</span></a>
     {{/each}}
@@ -219,7 +219,7 @@
           </td><td>
               <img src="http://stockcharts.com/c-sc/sc?s={{item}}&p=W&b=5&g=0&i=t99261714081&r=1408323404116"/>
           </td></tr></table>
-        <br>
+        <br/>
       </li>
     {{/each}}
     </ul>
@@ -270,7 +270,7 @@
     
     <section id="top"></section>        
     <a class="nav" href="http://finviz.com/screener.ashx?v=340&s=ta_topgainers&o=-change" target="_blank"/>FinViz Top Stocks Today </a>
-    <br>
+    <br/>
     {{#each item in model}}
        <a class="link-to" href="#{{item}}"><span class="label label-warning">{{item}}</span></a>
     {{/each}}
@@ -295,7 +295,7 @@
           </td><td>
               <img src="http://stockcharts.com/c-sc/sc?s={{item}}&p=W&b=5&g=0&i=t99261714081&r=1408323404116"/>
           </td></tr></table>
-        <br>
+        <br/>
       </li>
     {{/each}}
     </ul>
@@ -346,7 +346,7 @@
 
      <section id="top"></section>        
      <a class="nav" href="http://finviz.com/screener.ashx?v=340&s=ta_topgainers&o=-change" target="_blank"/>FinViz Top Stocks Today </a>
-     <br>
+     <br/>
     {{#each item in model}}
       <a class="link-to" href="#{{item}}"><span class="label label-warning">{{item}}</span></a>
     {{/each}}
@@ -371,7 +371,7 @@
           </td><td>
               <img src="http://stockcharts.com/c-sc/sc?s={{item}}&p=W&b=5&g=0&i=t99261714081&r=1408323404116"/>
           </td></tr></table>
-        <br>
+        <br/>
       </li>
     {{/each}}
     </ul>
@@ -422,7 +422,7 @@
 
      <section id="top"></section>        
      <a class="nav" href="http://finviz.com/screener.ashx?v=340&s=ta_topgainers&o=-change" target="_blank"/>FinViz Top Stocks Today </a>
-     <br>
+     <br/>
     {{#each item in model}}
       <a class="link-to" href="#{{item}}"><span class="label label-warning">{{item}}</span></a>
     {{/each}}
@@ -447,7 +447,7 @@
           </td><td>
               <img src="http://stockcharts.com/c-sc/sc?s={{item}}&p=W&b=5&g=0&i=t99261714081&r=1408323404116"/>
           </td></tr></table>
-        <br>
+        <br/>
       </li>
     {{/each}}
     </ul>
@@ -498,7 +498,7 @@
     
     <section id="top"></section>        
     <a class="nav" href="http://finviz.com/screener.ashx?v=340&s=ta_topgainers&o=-change" target="_blank"/>FinViz Top Stocks Today </a>
-    <br>
+    <br/>
     {{#each item in model}}
       <a class="link-to" href="#{{item}}"><span class="label label-warning">{{item}}</span></a>
     {{/each}}
@@ -523,7 +523,7 @@
           </td><td>
               <img src="http://stockcharts.com/c-sc/sc?s={{item}}&p=W&b=5&g=0&i=t99261714081&r=1408323404116"/>
           </td></tr></table>
-        <br>
+        <br/>
       </li>
     {{/each}}
     </ul>
@@ -574,7 +574,7 @@
     
     <section id="top"></section>        
     <a class="nav" href="http://finviz.com/screener.ashx?v=340&s=ta_topgainers&o=-change" target="_blank"/>FinViz Top Stocks Today </a>
-    <br>
+    <br/>
     {{#each item in model}}
       <a class="link-to" href="#{{item}}"><span class="label label-warning">{{item}}</span></a>
     {{/each}}
@@ -599,7 +599,7 @@
           </td><td>
               <img src="http://stockcharts.com/c-sc/sc?s={{item}}&p=W&b=5&g=0&i=t99261714081&r=1408323404116"/>
           </td></tr></table>
-        <br>
+        <br/>
       </li>
     {{/each}}
     </ul>
@@ -649,7 +649,7 @@
     
     <section id="top"></section>        
     <a class="nav" href="http://finviz.com/screener.ashx?v=340&s=ta_topgainers&o=-change" target="_blank"/>FinViz Top Stocks Today </a>
-    <br>
+    <br/>
     {{#each item in model}}
 <a class="link-to" href="#{{item}}"><span class="label label-warning">{{item}}</span></a>
     {{/each}}
@@ -674,7 +674,7 @@
           </td><td>
               <img src="http://stockcharts.com/c-sc/sc?s={{item}}&p=W&b=5&g=0&i=t99261714081&r=1408323404116"/>
           </td></tr></table>
-        <br>
+        <br/>
       </li>
     {{/each}}
     </ul>
@@ -726,7 +726,7 @@
 
   <section id="top"></section>        
     <a class="nav" href="http://finviz.com/screener.ashx?v=340&s=ta_topgainers&o=-change" target="_blank"/>FinViz Top Stocks Today </a>
-    <br>
+    <br/>
     {{#each item in model}}
  <a class="link-to" href="#{{item}}"><span class="label label-warning">{{item}}</span></a>
     {{/each}}
@@ -746,12 +746,12 @@
          <a href="https://twitter.com/search?q=%24{{item}}&src=ctag" target="_blank"/>Twitter</a>  
           <b> ... </b> 
         <a class="link-to" href="#top"><span class="label label-info">Back to Top</span></a>
-        <br><table><tr><td>
+        <br/><table><tr><td>
              <img src="http://stockcharts.com/c-sc/sc?s={{item}}&p=D&b=5&g=0&i=p64176622437&r=1457665058631"/>
           </td><td>
               <img src="http://stockcharts.com/c-sc/sc?s={{item}}&p=W&b=5&g=0&i=t99261714081&r=1408323404116"/>
           </td></tr></table>
-        <br>
+        <br/>
       </li>
     {{/each}}
 
@@ -803,7 +803,7 @@
 
      <section id="top"></section>        
      <a class="nav" href="http://finviz.com/screener.ashx?v=340&s=ta_topgainers&o=-change" target="_blank"/>FinViz Top Stocks Today </a>
-     <br>
+     <br/>
      
      {{#each item in model}}
        <a class="link-to" href="#{{item}}"><span class="label label-warning">{{item}}</span></a>
@@ -829,7 +829,7 @@
            <a href="https://twitter.com/search?q=%24{{item}}&src=ctag" target="_blank"/>Twitter</a>  
             <b> ... </b> 
         <a class="link-to" href="#top"><span class="label label-info">Back to Top</span></a>
-        <br>
+        <br/>
 
                 <img src="http://stockcharts.com/c-sc/sc?s={{item}}&p=D&b=5&g=0&i=p64176622437&r=1457665058631"/>
           
@@ -837,7 +837,7 @@
           
           </div>
 </div>
-        <br>
+        <br/>
       </li>
     {{/each}}
     </ul>


### PR DESCRIPTION
**Introduction:**
In accordance with the w3 HTML5 specification for HTML code, void tags (see reference) should be marked as self-closing. During a scan for repositories containing HTML files, we found HTML code in your repository that needed this improvement.

Even though the self-closing specification is not a strict requirement by web-browsers, and they will happily parse the tag anyhow - that is not an excuse for not writing specification valid code, and I am more than happy to help correct this. In the spirit of an open-source community! The changes in this PullRequest will not break your code in any way.

**References:**
https://www.w3.org/TR/html5/syntax.html#void-elements
